### PR TITLE
Support building in PlatformIO

### DIFF
--- a/src/ESP_WiFiManager.cpp
+++ b/src/ESP_WiFiManager.cpp
@@ -1,5 +1,5 @@
 /****************************************************************************************************************************
-   ESP_WiFiManager-Impl.h
+   ESP_WiFiManager.cpp
    For ESP8266 / ESP32 boards
 
    ESP_WiFiManager is a library for the ESP8266/Arduino platform
@@ -32,6 +32,8 @@
 
 #ifndef ESP_WiFiManager_Impl_h
 #define ESP_WiFiManager_Impl_h
+
+#include "ESP_WiFiManager.h"
 
 ESP_WMParameter::ESP_WMParameter(const char *custom)
 {


### PR DESCRIPTION
There are bunch of "multiple definition of 'ESP_WiFiManager' functions" errors at linking process in PlatformIO like:

> .pio\build\esp32\src\main.cpp.o: In function `ESP_WiFiManager::handleReset()':
> \.platformio\lib\arduinojson_id64\src\arduinojson\Serialization/JsonWriter.hpp:46: multiple definition of `ESP_WiFiManager::handleReset()'
> .pio\build\esp32\src\NidayandHelper.cpp.o:\motor-on-roller-blind-ws-master/.pio/libdeps/esp32/ESP_WiFiManager_ID6915/src/ESP_WiFiManager-Impl.h:1339: first defined here
> .pio\build\esp32\src\main.cpp.o: In function `ESP_WiFiManager::handleWifiSave()':
> main.cpp:(.text._ZN15ESP_WiFiManager14handleWifiSaveEv+0x0): multiple definition of `ESP_WiFiManager::handleWifiSave()'
> .pio\build\esp32\src\NidayandHelper.cpp.o:NidayandHelper.cpp:(.text._ZN15ESP_WiFiManager14handleWifiSaveEv+0x0): first defined here
> .pio\build\esp32\src\main.cpp.o: In function `ESP_WMParameter::ESP_WMParameter(char const*)':
> main.cpp:(.text._ZN15ESP_WMParameterC2EPKc+0x0): multiple definition of `ESP_WMParameter::ESP_WMParameter(char const*)'
> .pio\build\esp32\src\NidayandHelper.cpp.o:NidayandHelper.cpp:(.text._ZN15ESP_WMParameterC2EPKc+0x0): first defined here
> .pio\build\esp32\src\main.cpp.o: In function `ESP_WMParameter::ESP_WMParameter(char const*)':
> main.cpp:(.text._ZN15ESP_WMParameterC2EPKc+0x0): multiple definition of `ESP_WMParameter::ESP_WMParameter(char const*)'
> .pio\build\esp32\src\NidayandHelper.cpp.o:NidayandHelper.cpp:(.text._ZN15ESP_WMParameterC2EPKc+0x0): first defined here
> .pio\build\esp32\src\main.cpp.o: In function `ESP_WMParameter::init(char const*, char const*, char con

I'm not experienced CPP-developer, but there shouldn't be a implementation inside headers, it should be in .cpp.
This pull request fixes that and it's building ok in Platformio now.

I don't have configured Arduino IDE, so it's not tested there actually. Will be great if someone test in Arduino IDE before merging also.

Thanks.