### PR TITLE
Update example ConfigOnDoubleReset.ino to avoid error checking ESP_DoubleResetDetector version

### DIFF
--- a/examples/ConfigOnDoubleReset/ConfigOnDoubleReset.ino
+++ b/examples/ConfigOnDoubleReset/ConfigOnDoubleReset.ino
@@ -575,7 +575,7 @@ void setup()
   Serial.print("\nStarting ConfigOnDoubleReset with DoubleResetDetect using " + String(FS_Name));
   Serial.println(" on " + String(ARDUINO_BOARD));
   Serial.println("ESP_WiFiManager Version " + String(ESP_WIFIMANAGER_VERSION));
-  Serial.println("ESP_DoubleResetDetector Version " + String(ESP_DOUBLE_RESET_DETECTOR_VERSION));
+  Serial.println("ESP_DoubleResetDetector Version " + String(ESP_DOUBLERESETDETECTOR_VERSION));
 
   Serial.setDebugOutput(false);
 


### PR DESCRIPTION
Hi,

building the example code throws an error:

```
error: 'ESP_DOUBLE_RESET_DETECTOR_VERSION' was not declared in this scope
   Serial.println("ESP_DoubleResetDetector Version " + String(ESP_DOUBLE_RESET_DETECTOR_VERSION));
```

The line printing the double reset dectector version needs to be adjusted to:
```c
Serial.println("ESP_DoubleResetDetector Version " + String(ESP_DOUBLERESETDETECTOR_VERSION));
```

Environment:
IDE: Platform.io
Libs:
* khoih-prog/ESP_WiFiManager@1.3.0
* khoih-prog/ESP_DoubleResetDetector@1.0.3