### PR TITLE
Add support for Wifi hidden SSID scanning.

### DIFF
--- a/src/ESP_WiFiManager-Impl.h
+++ b/src/ESP_WiFiManager-Impl.h
@@ -1908,7 +1908,7 @@ int ESP_WiFiManager::scanWifiNetworks(int **indicesptr)
 {
   LOGDEBUG(F("Scanning Network"));
 
-  int n = WiFi.scanNetworks();
+  int n = WiFi.scanNetworks(false, true);
 
   LOGDEBUG1(F("scanWifiNetworks: Done, Scanned Networks n ="), n); 
 

--- a/src_cpp/ESP_WiFiManager.cpp
+++ b/src_cpp/ESP_WiFiManager.cpp
@@ -1905,7 +1905,7 @@ int ESP_WiFiManager::scanWifiNetworks(int **indicesptr)
 {
   LOGDEBUG(F("Scanning Network"));
 
-  int n = WiFi.scanNetworks();
+  int n = WiFi.scanNetworks(false, true);
 
   LOGDEBUG1(F("scanWifiNetworks: Done, Scanned Networks n ="), n); 
 

--- a/src_h/ESP_WiFiManager-Impl.h
+++ b/src_h/ESP_WiFiManager-Impl.h
@@ -1908,7 +1908,7 @@ int ESP_WiFiManager::scanWifiNetworks(int **indicesptr)
 {
   LOGDEBUG(F("Scanning Network"));
 
-  int n = WiFi.scanNetworks();
+  int n = WiFi.scanNetworks(false, true);
 
   LOGDEBUG1(F("scanWifiNetworks: Done, Scanned Networks n ="), n); 
 


### PR DESCRIPTION
WifiScan function supports hidden networks if you set a parameter (https://github.com/espressif/arduino-esp32/blob/371f382db7dd36c470bb2669b222adf0a497600d/libraries/WiFi/src/WiFiScan.cpp#L81).

https://github.com/revoxhere/duino-coin/commit/64da14a9c36a3c7fdbb7cb8718a68f57053a28f8

I tested on an esp32 running [esp32_iGrill](https://github.com/1mckenna/esp32_iGrill) and could see entries for both my hidden SSIDs and non-hidden SSIDs. When configured to use a hidden SSID the network connection was successful. 